### PR TITLE
Use a new Manager.get() method to make manager's getters consistent

### DIFF
--- a/datafiles/manager.py
+++ b/datafiles/manager.py
@@ -39,8 +39,8 @@ class Manager:
 
     def get(self, *args, **kwargs) -> HasDatafile:
         fields = dataclasses.fields(self.model)
-        args = list(args)
-        args += [Missing] * (len(fields) - len(args) - len(kwargs))
+        missing_args = [Missing] * (len(fields) - len(args) - len(kwargs))
+        args = (*args, *missing_args)
 
         with hooks.disabled():
             instance = self.model(*args, **kwargs)

--- a/datafiles/manager.py
+++ b/datafiles/manager.py
@@ -52,12 +52,14 @@ class Manager:
         try:
             return self.get(*args, **kwargs)
         except FileNotFoundError:
+            log.info("File not found")
             return None
 
     def get_or_create(self, *args, **kwargs) -> HasDatafile:
         try:
             return self.get(*args, **kwargs)
         except FileNotFoundError:
+            log.info(f"File not found, creating '{self.model.__name__}' object")
             return self.model(*args, **kwargs)
 
     def filter(self, **query):

--- a/datafiles/manager.py
+++ b/datafiles/manager.py
@@ -12,6 +12,8 @@ from typing_extensions import Protocol
 import log
 from parse import parse
 
+from . import hooks
+
 
 if TYPE_CHECKING:
     from .mapper import Mapper
@@ -33,31 +35,30 @@ class Manager:
         for filename in iglob(splatted):
             log.debug(f'Found matching path: {filename}')
             results = parse(pattern, filename)
-            fields = dataclasses.fields(self.model)
-            args = list(results.named.values())
-            args += [Missing] * (len(fields) - len(args))
-            yield self.model(*args)
+            yield self.get(*results.named.values())
 
-    def get_or_none(self, *args, **kwargs) -> Optional[HasDatafile]:
-        original_manual = self.model.Meta.datafile_manual
+    def get(self, *args, **kwargs) -> HasDatafile:
+        fields = dataclasses.fields(self.model)
+        args = list(args)
+        args += [Missing] * (len(fields) - len(args) - len(kwargs))
 
-        self.model.Meta.datafile_manual = True
-        instance = self.model(*args, **kwargs)
-        self.model.Meta.datafile_manual = original_manual
-
-        if instance.datafile.exists:
-            instance.datafile._manual = original_manual
-            return instance
-
-        return None
-
-    def get_or_create(self, *args, **kwargs) -> HasDatafile:
-        instance = self.model(*args, **kwargs)
-
-        if not instance.datafile.exists:
-            instance.datafile.save()
+        with hooks.disabled():
+            instance = self.model(*args, **kwargs)
+            instance.datafile.load()
 
         return instance
+
+    def get_or_none(self, *args, **kwargs) -> Optional[HasDatafile]:
+        try:
+            return self.get(*args, **kwargs)
+        except FileNotFoundError:
+            return None
+
+    def get_or_create(self, *args, **kwargs) -> HasDatafile:
+        try:
+            return self.get(*args, **kwargs)
+        except FileNotFoundError:
+            return self.model(*args, **kwargs)
 
     def filter(self, **query):
         for item in self.all():


### PR DESCRIPTION
This is especially useful with `get_or_none` and `get_or_create` methods,
because they can now leverage the argument filling logic used in `all`, and
thus be able to run without specifying all arguments.

That way you can just give them the arguments that are needed to find the
datafile, and then they will load the other values if the file exist, fallback
if not (either by returning `None` or creating the said datafile, as before).

Edit: creation as a fallback will fail if mandatory arguments are missing. 