### PR TITLE
Support filtering for nested values (using __ as a delimeter)

### DIFF
--- a/datafiles/manager.py
+++ b/datafiles/manager.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import dataclasses
 import inspect
 import os
+from functools import reduce
 from glob import iglob
 from pathlib import Path
 from typing import TYPE_CHECKING, Iterator, Optional
@@ -104,7 +105,8 @@ class Manager:
         for item in self.all(_exclude=_exclude):
             match = True
             for key, value in query.items():
-                if getattr(item, key) != value:
+                # The use of reduce helps to handle nested attribute queries
+                if reduce(getattr, [item] + key.split('__')) != value:  # type: ignore
                     match = False
             if match:
                 yield item

--- a/datafiles/tests/test_manager.py
+++ b/datafiles/tests/test_manager.py
@@ -1,5 +1,6 @@
 # pylint: disable=unused-variable
 
+import typing
 from dataclasses import dataclass
 from unittest.mock import patch
 
@@ -10,9 +11,15 @@ from datafiles.model import create_model
 
 
 @dataclass
+class Nested:
+    name: str
+
+
+@dataclass
 class MyClass:
     foo: int
     bar: int
+    nested: typing.Optional[Nested] = None
 
 
 def describe_manager():
@@ -26,12 +33,14 @@ def describe_manager():
         @patch('datafiles.mapper.Mapper.exists', True)
         @patch('datafiles.mapper.Mapper.modified', False)
         def when_file_exists(mock_load, expect, manager):
-            expect(manager.get_or_none(foo=1, bar=2)) == MyClass(foo=1, bar=2)
+            expect(manager.get_or_none(foo=1, bar=2, nested=None)) == MyClass(
+                foo=1, bar=2
+            )
             expect(mock_load.called).is_(True)
 
         @patch('datafiles.mapper.Mapper.exists', False)
         def when_file_missing(expect, manager):
-            expect(manager.get_or_none(foo=3, bar=4)).is_(None)
+            expect(manager.get_or_none(foo=3, bar=4, nested=None)).is_(None)
 
     def describe_get_or_create():
         @patch('datafiles.mapper.Mapper.save')
@@ -39,7 +48,9 @@ def describe_manager():
         @patch('datafiles.mapper.Mapper.exists', True)
         @patch('datafiles.mapper.Mapper.modified', False)
         def when_file_exists(mock_save, mock_load, expect, manager):
-            expect(manager.get_or_create(foo=1, bar=2)) == MyClass(foo=1, bar=2)
+            expect(manager.get_or_create(foo=1, bar=2, nested=None)) == MyClass(
+                foo=1, bar=2
+            )
             expect(mock_save.called).is_(True)
             expect(mock_load.called).is_(False)
 
@@ -47,7 +58,9 @@ def describe_manager():
         @patch('datafiles.mapper.Mapper.load')
         @patch('datafiles.mapper.Mapper.exists', False)
         def when_file_missing(mock_save, mock_load, expect, manager):
-            expect(manager.get_or_create(foo=1, bar=2)) == MyClass(foo=1, bar=2)
+            expect(manager.get_or_create(foo=1, bar=2, nested=None)) == MyClass(
+                foo=1, bar=2
+            )
             expect(mock_save.called).is_(True)
             expect(mock_load.called).is_(True)
 
@@ -66,4 +79,9 @@ def describe_manager():
         @patch('datafiles.mapper.Mapper.exists', False)
         def with_partial_positional_arguments(expect, manager):
             items = list(manager.filter(foo=1))
+            expect(items) == []
+
+        @patch('datafiles.mapper.Mapper.exists', False)
+        def with_nested_key_query(expect, manager):
+            items = list(manager.filter(nested__name='John Doe'))
             expect(items) == []


### PR DESCRIPTION
This PR adds support for filtering for nested values, allowing user to perform arbitrary nested queries:

```python
    matching = list(Person.objects.filter(nested__attribute=42))
    # or even
    matching = list(Person.objects.filter(nested__nested__nested__attribute=42))
```

Side note: The `get_or_none` implementation seems to require enumerating all attributes, including optional ones (tests would fail unless I added `nested=None` as an explicit argument), which was unexpected. Possibly an issue that should be investigated.