### PR TITLE
Optional "self." in patterns, frozen dataclass support, and more

### DIFF
--- a/datafiles/config.py
+++ b/datafiles/config.py
@@ -15,6 +15,7 @@ class Meta:
     datafile_manual: bool = False
     datafile_defaults: bool = False
     datafile_infer: bool = False
+    datafile_use_self: bool = True
 
 
 def load(obj) -> Meta:
@@ -30,5 +31,7 @@ def load(obj) -> Meta:
         meta.datafile_defaults = obj.Meta.datafile_defaults
     with suppress(AttributeError):
         meta.datafile_infer = obj.Meta.datafile_infer
+    with suppress(AttributeError):
+        meta.datafile_use_self = obj.Meta.datafile_use_self
 
     return meta

--- a/datafiles/decorators.py
+++ b/datafiles/decorators.py
@@ -13,6 +13,7 @@ def datafile(
     manual: bool = Meta.datafile_manual,
     defaults: bool = Meta.datafile_defaults,
     infer: bool = Meta.datafile_infer,
+    use_self: bool = Meta.datafile_use_self,
     **kwargs,
 ):
     """Synchronize a data class to the specified path."""
@@ -27,7 +28,7 @@ def datafile(
         if dataclasses.is_dataclass(cls):
             dataclass = cls
         else:
-            dataclass = dataclasses.dataclass(cls)
+            dataclass = dataclasses.dataclass(cls, **kwargs)
 
         return create_model(
             dataclass,
@@ -36,6 +37,7 @@ def datafile(
             manual=manual,
             defaults=defaults,
             infer=infer,
+            use_self=use_self,
         )
 
     return decorator

--- a/datafiles/manager.py
+++ b/datafiles/manager.py
@@ -77,7 +77,7 @@ class Manager:
             model.Model.__post_init__(instance)
 
             try:
-                instance.datafile.load()
+                instance.datafile.load(_first_load=True)
             except MarkedYAMLError as e:
                 log.critical(
                     f"Deleting invalid YAML: {instance.datafile.path} ({e.problem})"

--- a/datafiles/model.py
+++ b/datafiles/model.py
@@ -15,7 +15,8 @@ class Model:
     def __post_init__(self):
         log.debug(f"Initializing {self.__class__} object")
 
-        self.datafile = create_mapper(self)
+        # Using object.__setattr__ in case of frozen dataclasses
+        object.__setattr__(self, 'datafile', create_mapper(self))
 
         if settings.HOOKS_ENABLED:
             with hooks.disabled():
@@ -43,7 +44,7 @@ class Model:
 
 
 def create_model(
-    cls, *, attrs=None, manual=None, pattern=None, defaults=None, infer=None
+    cls, *, attrs=None, manual=None, pattern=None, defaults=None, infer=None, use_self=None
 ):
     """Patch model attributes on to an existing dataclass."""
     log.debug(f"Converting {cls} to a datafile model")
@@ -66,6 +67,8 @@ def create_model(
         m.datafile_defaults = defaults
     if not hasattr(cls, "Meta") and infer is not None:
         m.datafile_infer = infer
+    if not hasattr(cls, "Meta") and use_self is not None:
+        m.datafile_use_self = use_self
 
     cls.Meta = m
 

--- a/datafiles/tests/test_mapper.py
+++ b/datafiles/tests/test_mapper.py
@@ -31,6 +31,7 @@ def describe_mapper():
             manual=Meta.datafile_manual,
             defaults=Meta.datafile_defaults,
             infer=Meta.datafile_infer,
+            use_self=Meta.datafile_use_self,
         )
 
     def describe_path():


### PR DESCRIPTION
There are four main features / improvements in this PR which I'll cover below. I want to start by saying the test suite was infinitely helpful in developing this PR and I hope to learn from your tests in my own work.

1. It seemed to me that the ability to forgo all the `self.` strings in patterns would be nice, so I made this an option on `config.Meta` which maintains the previous behavior by default but could be changed in the future (probably a major version, it would be a breaking change to make `Meta.use_self=False` the default, users could be informed that the old functionality can be maintained by setting `Meta.use_self=True`). The following example demonstrates the change.
```py
@datafiles.datafile('{a}.toml', use_self=False, manual=True)
class T:
    a: int
    b: int = 2
```

2. I added support for frozen dataclasses. This mostly involved switching to `object.__setattr__` in a few places. I also added some protection against loading instances of frozen dataclasses more than once, as this could mutate the frozen object. The example below would fail previously, but works now.
```py
@datafiles.datafile('{self.a}.toml', manual=True)
@dataclasses.dataclass(frozen=True)
class T:
    a: int
    b: int = 2
```

3. I added kwarg passthrough for any time `datafiles` creates a `dataclass` for you. The example above can become:
```py
@datafiles.datafile('{self.a}.toml', manual=True, frozen=True)
class T3:
    a: int
    b: int = 2
```

4. I updated `Manager.get` to be a bit more flexible. It now allows only the arguments which are required for path construction, i.e., those which appear in the pattern to be passed either as args or kwargs. Previously, passing as kwargs only when multiple non-default fields existed would fail as in the example below.
```py
@datafiles.datafile('{self.a}.toml', manual=True)
class T2:
    a: int
    b: int

T2.objects.get(a=5)

# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
#   File "/path/to/repo/datafiles/manager.py", line 43, in get
#     instance = self.model(*args, **kwargs)
#                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/path/to/repo/datafiles/model.py", line 82, in modified_init
#     init(self, *args, **kwargs)
# TypeError: T2.__init__() got multiple values for argument 'a'
```

NOTE: For all examples in this PR, I had a `5.toml` file in the cwd with the content `b = 4`.

To wrap things up, I want to mention that I need some guidance on adding tests for the new features as that is something I wasn't sure about. That said, I have of course tested things manually. However, for the test suite I wanted to know where would be the best place to put tests for `Meta.use_self=False` and frozen dataclass support.

I hope you find these features and improvements worth adding, otherwise I'll have to maintain a fork (as I need these features myself) and who wants to do that!