### PR TITLE
`Manager.get` fix

### DIFF
--- a/datafiles/manager.py
+++ b/datafiles/manager.py
@@ -50,7 +50,7 @@ class Manager:
             pattern = self.model.Meta.datafile_pattern
             args_iter = iter(args)
             for field in fields:
-                placeholder = '{{self.{field.name}}}'.format(field=field)
+                placeholder = f"{{self.{field.name}}}"
 
                 try:
                     # we always need to consume an arg if it exists,
@@ -62,7 +62,7 @@ class Manager:
                 if placeholder in pattern:
                     if value is _NOT_PASSED:
                         raise MissingPlaceholderArgumentError(
-                            f'Missing value for placeholder field {field.name}'
+                            f"Missing value for placeholder field {field.name}"
                         )
 
                 if value is not _NOT_PASSED:


### PR DESCRIPTION
I updated `Manager.get` to be a bit more flexible. It now allows only the arguments which are required for path construction, i.e., those which appear in the pattern, to be passed either as args or kwargs. Previously, passing as kwargs only when multiple non-default fields existed would fail as in the example below, and there may have been other bugs with the previous implementation that I didn't discover.

```py
@datafiles.datafile('{self.a}.toml', manual=True)
class T2:
    a: int
    b: int

T2.objects.get(a=5)

# Results in the following in main, works in PR
# Traceback (most recent call last):
#   File "<stdin>", line 1, in <module>
#   File "/path/to/repo/datafiles/manager.py", line 43, in get
#     instance = self.model(*args, **kwargs)
#                ^^^^^^^^^^^^^^^^^^^^^^^^^^^
#   File "/path/to/repo/datafiles/model.py", line 82, in modified_init
#     init(self, *args, **kwargs)
# TypeError: T2.__init__() got multiple values for argument 'a'
```