### PR TITLE
Adds kwargs passthrough for dataclass construction that was missing

### DIFF
--- a/datafiles/decorators.py
+++ b/datafiles/decorators.py
@@ -27,7 +27,7 @@ def datafile(
         if dataclasses.is_dataclass(cls):
             dataclass = cls
         else:
-            dataclass = dataclasses.dataclass(cls)
+            dataclass = dataclasses.dataclass(cls, **kwargs)
 
         return create_model(
             dataclass,


### PR DESCRIPTION
I added kwarg passthrough for any time `datafiles` creates a `dataclass` for you. The following example illustrates:

```py
# in main
@datafiles.datafile('{self.a}.toml', manual=True)
@dataclasses.dataclass(frozen=True)
class T:
    a: int
    b: int = 2

# becomes
@datafiles.datafile('{self.a}.toml', manual=True, frozen=True)
class T3:
    a: int
    b: int = 2
```