### PR TITLE
Support renaming files if the filename attributes were modified

### DIFF
--- a/datafiles/config.py
+++ b/datafiles/config.py
@@ -15,6 +15,7 @@ class Meta:
     datafile_manual: bool = False
     datafile_defaults: bool = False
     datafile_infer: bool = False
+    datafile_rename: bool = False
 
 
 def load(obj) -> Meta:
@@ -30,5 +31,7 @@ def load(obj) -> Meta:
         meta.datafile_defaults = obj.Meta.datafile_defaults
     with suppress(AttributeError):
         meta.datafile_infer = obj.Meta.datafile_infer
+    with suppress(AttributeError):
+        meta.datafile_rename = obj.Meta.datafile_rename
 
     return meta

--- a/datafiles/decorators.py
+++ b/datafiles/decorators.py
@@ -13,6 +13,7 @@ def datafile(
     manual: bool = Meta.datafile_manual,
     defaults: bool = Meta.datafile_defaults,
     infer: bool = Meta.datafile_infer,
+    rename: bool = Meta.datafile_rename,
     **kwargs,
 ):
     """Synchronize a data class to the specified path."""
@@ -36,6 +37,7 @@ def datafile(
             manual=manual,
             defaults=defaults,
             infer=infer,
+            rename=rename,
         )
 
     return decorator

--- a/datafiles/mapper.py
+++ b/datafiles/mapper.py
@@ -28,6 +28,7 @@ class Mapper:
         manual: bool,
         defaults: bool,
         infer: bool,
+        rename: bool,
         root: Optional[Mapper] = None,
     ) -> None:
         assert manual is not None
@@ -40,6 +41,7 @@ class Mapper:
         self.attrs = attrs
         self._pattern = pattern
         self._manual = manual
+        self._rename = rename
         self.defaults = defaults
         self._infer = infer
         self._last_load = 0.0
@@ -319,6 +321,7 @@ def create_mapper(obj, root=None) -> Mapper:
         attrs=attrs or {},
         pattern=pattern,
         manual=meta.datafile_manual,
+        rename=meta.datafile_rename,
         defaults=meta.datafile_defaults,
         infer=meta.datafile_infer,
         root=root,

--- a/datafiles/model.py
+++ b/datafiles/model.py
@@ -45,7 +45,14 @@ class Model:
 
 
 def create_model(
-    cls, *, attrs=None, manual=None, pattern=None, defaults=None, infer=None
+    cls,
+    *,
+    attrs=None,
+    manual=None,
+    pattern=None,
+    defaults=None,
+    infer=None,
+    rename=None,
 ):
     """Patch model attributes on to an existing dataclass."""
     log.debug(f"Converting {cls} to a datafile model")
@@ -68,6 +75,8 @@ def create_model(
         m.datafile_defaults = defaults
     if not hasattr(cls, "Meta") and infer is not None:
         m.datafile_infer = infer
+    if not hasattr(cls, "Meta") and rename is not None:
+        m.datafile_rename = rename
 
     cls.Meta = m
 

--- a/datafiles/tests/test_mapper.py
+++ b/datafiles/tests/test_mapper.py
@@ -31,6 +31,7 @@ def describe_mapper():
             manual=Meta.datafile_manual,
             defaults=Meta.datafile_defaults,
             infer=Meta.datafile_infer,
+            rename=Meta.datafile_rename,
         )
 
     def describe_path():

--- a/datafiles/utils.py
+++ b/datafiles/utils.py
@@ -141,6 +141,14 @@ def read(filename: str, *, display=False) -> str:
     return text
 
 
+def remove(filename_or_path: Union[str, Path]) -> None:
+    """Remove a given file, if it exists."""
+    filepath = Path(filename_or_path)
+    if filepath.exists():
+        filepath.unlink()
+        log.debug("Removed filepath: %s", str(filepath))
+
+
 def display(path: Path, data: Dict) -> None:
     """Display data read from a file."""
     message = f"Data from file: {path}"


### PR DESCRIPTION
This MR implements the necessary logic to allow the Mapper to write the datafile to a new location if the filepath has changed due to the user changing the attributes that are reflected in the filepath itself. The behaviour is gated behind `rename=True` flag (or its equivalents in the Meta class).

Prior to merging:
* tests to cover the behavior should be added
* documentation should be added

Closes #303.