### PR TITLE
Use safe_load in formats

### DIFF
--- a/datafiles/formats.py
+++ b/datafiles/formats.py
@@ -104,7 +104,7 @@ class YAML(Formatter):
         yaml = _YAML()
         yaml.preserve_quotes = True  # type: ignore
         try:
-            return yaml.load(file_object)
+            return yaml.safe_load(file_object)
         except NotImplementedError as e:
             log.error(str(e))
             return {}


### PR DESCRIPTION
`yaml.load()` in `datafiles/formats.py` doesn't pass a safe Loader. This can deserialize arbitrary Python objects and is an RCE risk if the YAML comes from user input or the network. Switched to `yaml.safe_load()`.