### PR TITLE
Bump pygments to 2.20.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ markdown==3.9 ; python_version >= "3.10" and python_version < "4.0"
 mkdocs-get-deps==0.2.0 ; python_version >= "3.10" and python_version < "4.0"
 mkdocs==1.6.1 ; python_version >= "3.10" and python_version < "4.0"
 jupyterlab-pygments==0.2.2 ; python_version >= "3.10" and python_version < "4.0" and os_name != "nt"
-pygments==2.20.0 ; python_version >= "3.10" and python_version < "4.0"
+pygments==2.20.0


### PR DESCRIPTION
Noticed some outdated dependencies with known CVEs:

- `pygments` 2.19.2 -> 2.20.0 (CVE-2026-4539)

Bumped each one to the minimum safe version.